### PR TITLE
Add option to only use angles for the epicardium

### DIFF
--- a/src/ldrb/calculus.py
+++ b/src/ldrb/calculus.py
@@ -297,6 +297,7 @@ def compute_fiber_sheet_system(
     beta_epi_rv,
     beta_endo_sept,
     beta_epi_sept,
+    epi_only=False,
 ):
     grad_lv = np.zeros(3)
     grad_rv = np.zeros(3)
@@ -383,8 +384,11 @@ def compute_fiber_sheet_system(
         Q_epi = axis(grad_ab, grad_epi)
         Q_epi = orient(Q_epi, alpha_w, beta_w)
 
-        Q_endo = bislerp(Q_lv, Q_rv, depth)
-        Q_fiber = bislerp(Q_endo, Q_epi, epi)
+        if epi_only:
+            Q_fiber = Q_epi
+        else:
+            Q_endo = bislerp(Q_lv, Q_rv, depth)
+            Q_fiber = bislerp(Q_endo, Q_epi, epi)
 
         f0[xdofs[i]] = Q_fiber[0, 0]
         f0[ydofs[i]] = Q_fiber[1, 0]

--- a/src/ldrb/ldrb.py
+++ b/src/ldrb/ldrb.py
@@ -52,6 +52,7 @@ def compute_fiber_sheet_system(
     beta_epi_rv: float | None = None,
     beta_endo_sept: float | None = None,
     beta_epi_sept: float | None = None,
+    epi_only: bool = False,
 ) -> io.FiberSheetSystem:
     """
     Compute the fiber-sheets system on all degrees of freedom.
@@ -141,6 +142,7 @@ def compute_fiber_sheet_system(
         beta_epi_rv,
         beta_endo_sept,
         beta_epi_sept,
+        epi_only=epi_only,
     )
 
     return io.FiberSheetSystem(f0=f0, s0=s0, n0=n0)
@@ -211,6 +213,7 @@ def dolfinx_ldrb(
     beta_epi_rv: float | None = None,
     beta_endo_sept: float | None = None,
     beta_epi_sept: float | None = None,
+    epi_only: bool = False,
     **kwargs,
 ) -> io.LDRBOutput:
     r"""
@@ -279,7 +282,10 @@ def dolfinx_ldrb(
             Sheet angle at the septum endocardium.
         beta_epi_sept : scalar
             Sheet angle at the septum epicardium.
-
+    epi_only : bool
+        If true, then only the angles on the epicardial
+        surface will be used. This is a hack to make it
+        possible to compute purely longitudinal fibers
     """
     # Print warning of unused arguments
     if kwargs:
@@ -319,6 +325,7 @@ def dolfinx_ldrb(
         beta_epi_rv=beta_epi_rv,
         beta_endo_sept=beta_endo_sept,
         beta_epi_sept=beta_epi_sept,
+        epi_only=epi_only,
         **data,
     )  # type:ignore
 


### PR DESCRIPTION
To make it possible to create longitudinal fibers for the BiV using `alpha_endo_lv = alpha_epi_lv = -90`.